### PR TITLE
Feature - Improve ip address detection

### DIFF
--- a/src/runNameserver.sh
+++ b/src/runNameserver.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-python -m Pyro4.naming -n `hostname -I`
+python -m Pyro4.naming -n 0.0.0.0


### PR DESCRIPTION
Get rid of the need to fork `hostname -I` by listening on all IP addresses or using python to work out an IP address.

I've only been able to test this locally. I'm not 100% sure it will work right on an actual network of 2 or 3 machines.
