### PR TITLE
Fix removal of dead clients

### DIFF
--- a/src/avx/controller/Controller.py
+++ b/src/avx/controller/Controller.py
@@ -110,7 +110,7 @@ class Controller(object):
                 logging.debug("Client call returned " + str(result))
             except:
                 logging.exception("Failed to call function on registered client " + str(uri) + ", removing.")
-                self.clients.pop(uri)
+                self.clients.remove(uri)
 
     def getVersion(self):
         return self.version

--- a/src/avx/controller/tests/TestController.py
+++ b/src/avx/controller/tests/TestController.py
@@ -96,7 +96,6 @@ class TestController(TestCase):
         c.callAllClients(lambda c: c.doesNotExist())
         self.assertEqual([], c.clients)
 
-
     def testVersionCompatibility(self):
         table = [
             # remote, local, expected

--- a/src/avx/controller/tests/TestController.py
+++ b/src/avx/controller/tests/TestController.py
@@ -87,6 +87,16 @@ class TestController(TestCase):
         master.daemon.shutdown()
         slave.daemon.shutdown()
 
+    def testBadClientDisconnect(self):
+        c = Controller()
+
+        c.registerClient("DOES_NOT_EXIST")
+        self.assertEqual(["DOES_NOT_EXIST"], c.clients)
+
+        c.callAllClients(lambda c: c.doesNotExist())
+        self.assertEqual([], c.clients)
+
+
     def testVersionCompatibility(self):
         table = [
             # remote, local, expected


### PR DESCRIPTION
This clearly never worked; but now the controller shouldn't fall over on calls to `callAllClients` if some of them are dead.

Fixes #59.