### PR TITLE
Improve client messaging

### DIFF
--- a/.pydevproject
+++ b/.pydevproject
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?eclipse-pydev version="1.0"?><pydev_project>
-<pydev_pathproperty name="org.python.pydev.PROJECT_SOURCE_PATH">
-<path>/avx/src</path>
-</pydev_pathproperty>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
-</pydev_project>

--- a/README.md
+++ b/README.md
@@ -166,3 +166,37 @@ Currently the devices best supported include:
 
 In many cases support is partial but straightforward to improve - patches
 welcome!
+
+## Cross-client communication
+
+`avx` includes a mechanism for cross-client, and controller-to-client, communication.
+Clients should override the `handleMessage(msgType, source, data)` method to handle
+messages, which are sent via the controller's `broadcast` method. All messages are
+broadcast to all currently-connected clients. The arguments to `broadcast`, which are
+the same as those to `handleMessage`, are:
+ 
+ * `msgType`: string representing the type of message. Built-in message types are defined
+   in `avx.Client.MessageTypes` but client implementations are free to specify their own
+   as required.
+ * `source`: the origin of this message. When called from devices, this will be the device
+   ID of the device that calls `broadcast`. Client implementations may use this field as
+   required.
+ * `data`: the message payload. May be any Python object, or `None`.
+
+Clients may broadcast messages by calling `Controller.broadcast()` or by scheduling a
+`BroadcastEvent`, for example as part of a macro sequence. 
+
+Built-in message types currently include:
+
+ * `avx.Client.MessageTypes.OUTPUT_MAPPING`: sent by video switcher devices to describe their
+   current output state. `source` will be the device ID of the switcher. `data` will be a
+   `dict` whose keys are the numbered outputs of the switcher, and whose values are the
+   numbered inputs. For example, a switcher currently displaying input 1 on output 4 may send
+   the data
+   
+   ```{ 4: 1 }```
+   
+   Note that the complete state of the switcher may not be represented (a single message may
+   only describe a single output state). Nor is it guaranteed that such a message will
+   automatically be sent when a switcher changes state (the Inline IN3808, for example, only
+   sends its state when asked for).

--- a/src/avx/Client.py
+++ b/src/avx/Client.py
@@ -30,3 +30,7 @@ class Client(threading.Thread):
     @Pyro4.expose
     def handleMessage(self, msgType, sourceDeviceID, data):
         pass
+
+
+class MessageTypes(object):
+    OUTPUT_MAPPING = "avx.client.OutputMapping"

--- a/src/avx/Client.py
+++ b/src/avx/Client.py
@@ -4,6 +4,7 @@ Created on 8 Apr 2013
 @author: jrem
 '''
 from avx import PyroUtils
+
 import Pyro4
 import atexit
 import threading
@@ -25,3 +26,7 @@ class Client(threading.Thread):
 
     def getHostIP(self):
         return Pyro4.config.HOST
+
+    @Pyro4.expose
+    def handleMessage(self, msgType, sourceDeviceID, data):
+        pass

--- a/src/avx/Sequencer.py
+++ b/src/avx/Sequencer.py
@@ -123,3 +123,13 @@ class LogEvent(object):
 
     def execute(self, controller):
         logging.log(self.level, self.msg)
+
+
+class BroadcastEvent(object):
+    def __init__(self, msgType, source, data):
+        self.msgType = msgType
+        self.source = source
+        self.data = data
+
+    def execute(self, controller):
+        controller.broadcast(self.msgType, self.source, self.data)

--- a/src/avx/controller/Controller.py
+++ b/src/avx/controller/Controller.py
@@ -132,7 +132,7 @@ class Controller(object):
             try:
                 logging.debug("Calling handleMessage on client at {}".format(uri))
                 client = Pyro4.Proxy(uri)
-                result = client.handleMessage()
+                result = client.handleMessage(msgType, source, data)
                 logging.debug("Client call returned " + str(result))
             except Exception:
                 logging.exception("Failed to call handleMessage on registered client {}, removing.".format(uri))

--- a/src/avx/controller/Controller.py
+++ b/src/avx/controller/Controller.py
@@ -159,7 +159,7 @@ class Controller(object):
         self.devices[device.deviceID] = device
         if hasattr(device, "registerDispatcher") and callable(getattr(device, "registerDispatcher")):
             device.registerDispatcher(self)
-        device.broadcast = self.broadcast
+        device.broadcast = lambda t, b: self.broadcast(t, device.deviceID, b)
 
     def getDevice(self, deviceID):
         return self.devices[deviceID]
@@ -219,9 +219,6 @@ class Controller(object):
 
     def getLog(self):
         return self.logHandler.entries
-
-    def updateOutputMappings(self, mapping):
-        self.callAllClients(lambda c: c.updateOutputMappings(mapping))
 
 
 class ControllerProxy(object):

--- a/src/avx/controller/Controller.py
+++ b/src/avx/controller/Controller.py
@@ -125,18 +125,6 @@ class Controller(object):
         logging.info(str(len(self.clients)) + " client(s) still connected")
         self.saveConfig()
 
-    def callAllClients(self, function):
-        ''' function should take a client and do things to it'''
-        for uri in list(self.clients):
-            try:
-                logging.debug("Calling function " + function.__name__ + " with client at " + str(uri))
-                client = Pyro4.Proxy(uri)
-                result = function(client)
-                logging.debug("Client call returned " + str(result))
-            except Exception:
-                logging.exception("Failed to call function on registered client " + str(uri) + ", removing.")
-                self.unregisterClient(uri)
-
     def broadcast(self, msgType, source, data):
         ''' Send a message to all clients '''
         logging.info("Broadcast: {}, {}, {}".format(msgType, source, data))
@@ -207,15 +195,6 @@ class Controller(object):
 
     def sequence(self, *events):
         self.sequencer.sequence(*events)
-
-    def showPowerOnDialogOnClients(self):
-        self.callAllClients(lambda c: c.showPowerOnDialog())
-
-    def showPowerOffDialogOnClients(self):
-        self.callAllClients(lambda c: c.showPowerOffDialog())
-
-    def hidePowerDialogOnClients(self):
-        self.callAllClients(lambda c: c.hidePowerDialog())
 
     def getLog(self):
         return self.logHandler.entries

--- a/src/avx/controller/Controller.py
+++ b/src/avx/controller/Controller.py
@@ -137,6 +137,19 @@ class Controller(object):
                 logging.exception("Failed to call function on registered client " + str(uri) + ", removing.")
                 self.unregisterClient(uri)
 
+    def broadcast(self, msgType, source, data):
+        ''' Send a message to all clients '''
+        logging.info("Broadcast: {}, {}, {}".format(msgType, source, data))
+        for uri in list(self.clients):
+            try:
+                logging.debug("Calling handleMessage on client at {}".format(uri))
+                client = Pyro4.Proxy(uri)
+                result = client.handleMessage()
+                logging.debug("Client call returned " + str(result))
+            except Exception:
+                logging.exception("Failed to call handleMessage on registered client {}, removing.".format(uri))
+                self.unregisterClient(uri)
+
     def getVersion(self):
         return self.version
 
@@ -146,6 +159,7 @@ class Controller(object):
         self.devices[device.deviceID] = device
         if hasattr(device, "registerDispatcher") and callable(getattr(device, "registerDispatcher")):
             device.registerDispatcher(self)
+        device.broadcast = self.broadcast
 
     def getDevice(self, deviceID):
         return self.devices[deviceID]

--- a/src/avx/controller/tests/TestController.py
+++ b/src/avx/controller/tests/TestController.py
@@ -223,6 +223,18 @@ class TestController(TestCase):
 
         controller.broadcast.assert_called_once_with("TEST", "Test2", "Initialise")
 
+    @patch("avx.controller.Controller.Pyro4.Proxy")
+    def testBroadcast(self, moxy):
+        client = MagicMock()
+        client.handleMessage = MagicMock()
+        moxy.return_value = client
+
+        c = Controller()
+        c.registerClient("mock://uri")
+
+        c.broadcast("Test", "testBroadcast", "data")
+        client.handleMessage.assert_called_once_with("Test", "testBroadcast", "data")
+
     def testVersionCompatibility(self):
         table = [
             # remote, local, expected

--- a/src/avx/controller/tests/TestController.py
+++ b/src/avx/controller/tests/TestController.py
@@ -176,30 +176,8 @@ class TestController(TestCase):
         c.registerClient("DOES_NOT_EXIST")
         self.assertEqual(["DOES_NOT_EXIST"], c.clients)
 
-        c.callAllClients(lambda c: c.doesNotExist())
+        c.broadcast("Test", "Test message", None)
         self.assertEqual([], c.clients)
-
-    @patch("avx.controller.Controller.Pyro4")
-    def testCallsAllGoodClients(self, pyro4):
-        c = Controller()
-        c.registerClient("Bad")
-        c.registerClient("Good")
-
-        good = MagicMock()
-        good.clientMethod = MagicMock()
-
-        pyro4.Proxy = MagicMock()
-
-        pyro4.Proxy.side_effect = [Exception("Foo"), good]
-
-        c.callAllClients(lambda c: c.clientMethod("Bar"))
-
-        pyro4.Proxy.assert_has_calls([
-            call("Bad"),
-            call("Good")
-        ])
-
-        good.clientMethod.assert_called_once_with("Bar")
 
     def testPersistClientList(self):
         with create_temporary_copy(os.path.join(os.path.dirname(__file__), 'testConfig.json')) as confFile:
@@ -218,7 +196,7 @@ class TestController(TestCase):
 
             self.assertEqual(c2.clients, ["DOES_NOT_EXIST"])
 
-            c2.callAllClients(lambda c: c.notARealMethod())
+            c2.broadcast("Test", "Test message", None)
 
             with open(confFile.name, "r") as cf2:
                 withClient2 = json.load(cf2)

--- a/src/avx/controller/tests/TestController.py
+++ b/src/avx/controller/tests/TestController.py
@@ -231,13 +231,13 @@ class TestController(TestCase):
         controller.broadcast = MagicMock()
 
         controller.addDevice(device)
-        device.broadcast("TEST", "Test", None)
-        controller.broadcast.assert_called_once_with("TEST", "Test", None)
+        device.broadcast("TEST", None)
+        controller.broadcast.assert_called_once_with("TEST", "test", None)
         controller.broadcast.reset_mock()
 
         class DudDevice(Device):
             def initialise(self):
-                self.broadcast("TEST", "Test2", "Initialise")
+                self.broadcast("TEST", "Initialise")
 
         dd = DudDevice("Test2")
         controller.addDevice(dd)

--- a/src/avx/controller/tests/TestController.py
+++ b/src/avx/controller/tests/TestController.py
@@ -224,6 +224,27 @@ class TestController(TestCase):
                 withClient2 = json.load(cf2)
                 self.assertEqual(withClient2["clients"], [])
 
+    def testInjectBroadcast(self):
+        device = Device("test")
+        controller = Controller()
+
+        controller.broadcast = MagicMock()
+
+        controller.addDevice(device)
+        device.broadcast("TEST", "Test", None)
+        controller.broadcast.assert_called_once_with("TEST", "Test", None)
+        controller.broadcast.reset_mock()
+
+        class DudDevice(Device):
+            def initialise(self):
+                self.broadcast("TEST", "Test2", "Initialise")
+
+        dd = DudDevice("Test2")
+        controller.addDevice(dd)
+        controller.initialise()
+
+        controller.broadcast.assert_called_once_with("TEST", "Test2", "Initialise")
+
     def testVersionCompatibility(self):
         table = [
             # remote, local, expected

--- a/src/avx/devices/serial/Inline3808.py
+++ b/src/avx/devices/serial/Inline3808.py
@@ -1,3 +1,4 @@
+from avx.Client import MessageTypes
 from avx.devices.serial import SerialDevice
 
 
@@ -14,3 +15,22 @@ class Inline3808(SerialDevice):
 
     def sendInputToOutput(self, inChannel, outChannel):
         return self.sendCommand("[PT1O0" + str(outChannel) + "I0" + str(inChannel) + "]")
+
+    def requestStatus(self):
+        self.sendCommand("[VID]")
+
+    def hasFullMessage(self, recv_buffer):
+        return recv_buffer[-1] == "]"
+
+    def handleMessage(self, msgBytes):
+        msgString = ''.join(map(chr, msgBytes))
+        if len(msgString) == 13 and msgString[1:4] == "VID":
+            self.broadcast(
+                MessageTypes.OUTPUT_MAPPING,
+                {
+                    1: int(msgString[5]),
+                    2: int(msgString[7]),
+                    3: int(msgString[9]),
+                    4: int(msgString[11]),
+                }
+            )

--- a/src/avx/devices/serial/Kramer602.py
+++ b/src/avx/devices/serial/Kramer602.py
@@ -4,6 +4,7 @@ Created on 13 Nov 2012
 @author: jrem
 '''
 from avx.devices.serial import SerialDevice
+from avx.Client import MessageTypes
 
 import logging
 
@@ -43,7 +44,6 @@ class Kramer602(SerialDevice):
             if (msgBytes[1] & 0x20) == 0:  # Not just a "I switched successfully" message
                 outp = (((msgBytes[1] & 0x1F) - 1) % 2) + 1
                 inp = (((msgBytes[1] & 0x1F) - outp) / 2) + 1  # int(math.ceil((message[1] & 0x1F) + (2 / 2)) - 1)
-                for d in self.dispatchers:
-                    d.updateOutputMappings({self.deviceID: {outp: inp}})
+                self.broadcast(MessageTypes.OUTPUT_MAPPING, {outp: inp})
             else:
                 self.requestStatus()  # Request device to send current status so listener can intercept

--- a/src/avx/devices/serial/KramerVP88.py
+++ b/src/avx/devices/serial/KramerVP88.py
@@ -4,6 +4,7 @@ Created on 10 Nov 2012
 @author: james
 '''
 from avx.devices.serial import SerialDevice
+from avx.Client import MessageTypes
 
 import logging
 
@@ -40,5 +41,4 @@ class KramerVP88(SerialDevice):
             if (msgBytes[0] == 0x41) or (msgBytes[0] == 0x45):  # Notification of video switch or response to query
                 inp = msgBytes[1] - 0x80
                 outp = msgBytes[2] - 0x80
-                for d in self.dispatchers:
-                    d.updateOutputMappings({self.deviceID: {outp: inp}})
+                self.broadcast(MessageTypes.OUTPUT_MAPPING, {outp: inp})

--- a/src/avx/devices/serial/tests/TestDevices.py
+++ b/src/avx/devices/serial/tests/TestDevices.py
@@ -37,6 +37,19 @@ class TestDevices(unittest.TestCase):
         inline.sendInputToOutput(3, 2)
         self.assertEqual(list("[PT1O02I03]"), port.bytes)
 
+        inline.broadcast = MagicMock()
+        inline.handleMessage(map(ord, "[VID02000608]"))
+
+        inline.broadcast.assert_called_once_with(
+            "avx.client.OutputMapping",
+            {
+                1: 2,
+                2: 0,
+                3: 6,
+                4: 8
+            }
+        )
+
     def testKramerVP88(self):
         port = MockSerialPort()
         vp88 = KramerVP88("Test", port)

--- a/src/avx/devices/serial/tests/TestDevices.py
+++ b/src/avx/devices/serial/tests/TestDevices.py
@@ -385,14 +385,13 @@ class TestDevices(unittest.TestCase):
         c = Controller()
         c.addDevice(k)
 
-        dispatcher = NullDispatcher()
-        dispatcher.updateOutputMappings = MagicMock()
-        k.registerDispatcher(dispatcher)
+        k.broadcast = MagicMock()
+
         k.initialise()
         sleep(1)
         k.deinitialise()
 
-        dispatcher.updateOutputMappings.assert_called_with({'Test': {3: 2}})
+        k.broadcast.assert_called_with('avx.client.OutputMapping', {3: 2})
 
     def testKramer602Listener(self):
         port = MockSerialPort()
@@ -403,14 +402,13 @@ class TestDevices(unittest.TestCase):
         c = Controller()
         c.addDevice(k)
 
-        dispatcher = NullDispatcher()
-        dispatcher.updateOutputMappings = MagicMock()
-        k.registerDispatcher(dispatcher)
+        k.broadcast = MagicMock()
+
         k.initialise()
         sleep(1)
         k.deinitialise()
 
-        dispatcher.updateOutputMappings.assert_called_with({'Test': {1: 1}})
+        k.broadcast.assert_called_with('avx.client.OutputMapping', {1: 1})
 
         port = MockSerialPort()
         port.setDataForRead([chr(0x28), chr(0x8A)])  # Notification that input 5 sent to output 2
@@ -419,14 +417,13 @@ class TestDevices(unittest.TestCase):
         c = Controller()
         c.addDevice(k)
 
-        dispatcher = NullDispatcher()
-        dispatcher.updateOutputMappings = MagicMock()
-        k.registerDispatcher(dispatcher)
+        k.broadcast = MagicMock()
+
         k.initialise()
         sleep(1)
         k.deinitialise()
 
-        dispatcher.updateOutputMappings.assert_called_with({'Test': {2: 5}})
+        k.broadcast.assert_called_with('avx.client.OutputMapping', {2: 5})
 
     def testSerialDevice(self):
         port = MockSerialPort()

--- a/src/avx/tests/TestSequencer.py
+++ b/src/avx/tests/TestSequencer.py
@@ -2,7 +2,7 @@ import unittest
 from mock import MagicMock, call, patch
 from avx.controller.Controller import Controller
 from avx.Sequencer import Sequencer, Event, ControllerEvent, DeviceEvent,\
-    SleepEvent, LogEvent, CompositeEvent
+    SleepEvent, LogEvent, CompositeEvent, BroadcastEvent
 from time import sleep
 
 
@@ -72,3 +72,9 @@ class TestSequencer(unittest.TestCase):
         e = LogEvent(logging.INFO, "This is informational")
         self.performSequenceTest(e)
         logging.log.assert_called_once_with(logging.INFO, "This is informational")
+
+    def testBroadcastEvent(self):
+        self.controller.broadcast = MagicMock()
+        e = BroadcastEvent("TYPE", "SOURCE", "DATA")
+        self.performSequenceTest(e)
+        self.controller.broadcast.assert_called_once_with("TYPE", "SOURCE", "DATA")


### PR DESCRIPTION
This PR fixes #49 by adding a more structured and generic mechanism for inter-client and controller-to-client communication.

Clients may now override `handleMessage` in order to receive broadcasts sent via the controller, either from devices (e.g. video switcher changed state) or other clients (e.g. as part of a macro sequence).

The old API of `callAllClients` has been removed, along with the implementation-specific power-dialog-related functions. If your client relies on these functions, you will need to rewrite it to use the new `broadcast` method.