### PR TITLE
Add support for BMD HyperDeck TCP control

### DIFF
--- a/src/avx/devices/Device.py
+++ b/src/avx/devices/Device.py
@@ -9,6 +9,7 @@ class Device(object):
     def __init__(self, deviceID, httpAccessible=False, **kwargs):
         self.deviceID = deviceID
         self.httpAccessible = httpAccessible
+        self.log = logging.getLogger(deviceID)
 
     def initialise(self):
         '''

--- a/src/avx/devices/net/atem/atem.py
+++ b/src/avx/devices/net/atem/atem.py
@@ -5,7 +5,6 @@ from .getter import ATEMGetter
 from .sender import ATEMSender
 from .receiver import ATEMReceiver
 
-import logging
 import socket
 import struct
 import threading
@@ -23,7 +22,6 @@ class ATEM(Device, ATEMGetter, ATEMSender, ATEMReceiver):
         super(ATEM, self).__init__(deviceID, **kwargs)
         self.ipAddr = ipAddr
         self.port = port
-        self.log = logging.getLogger(deviceID)
         self.recv_thread = None
 
     def initialise(self):

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -45,8 +45,8 @@ def _int(string):
 
 
 class HyperDeck(Device):
-    def __init__(self, deviceID, ipAddress, port=9993):
-        super(HyperDeck, self).__init__(deviceID)
+    def __init__(self, deviceID, ipAddress, port=9993, **kwargs):
+        super(HyperDeck, self).__init__(deviceID, *kwargs)
         self.remote = (ipAddress, port)
         self._recv_thread = None
 

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -23,6 +23,12 @@ class SlotState(Enum):
     MOUNTED = 'mounted'
 
 
+class MessageTypes(object):
+    _PREFIX = "avx.devices.net.hyperdeck."
+    TRANSPORT_STATE_CHANGED = _PREFIX + "TransportStateChanged"
+    SLOT_STATE_CHANGED = _PREFIX + "SlotStateChanged"
+
+
 def _bool(string):
     if string == "true":
         return True
@@ -123,6 +129,7 @@ class HyperDeck(Device):
             'slot id': _int
         }
         self._store_state(self._state['transport'], extra, mapping)
+        self.broadcast(MessageTypes.TRANSPORT_STATE_CHANGED, self._state['transport'])
 
     def _recv_508(self, payload, extra):
         self._recv_208(payload, extra)
@@ -140,6 +147,7 @@ class HyperDeck(Device):
         }
 
         self._store_state(self._state['slots'].setdefault(slot, {}), extra, mapping)
+        self.broadcast(MessageTypes.SLOT_STATE_CHANGED, self._state['slots'])
 
     def _recv_502(self, payload, extra):
         self._recv_202(payload, extra)

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -92,7 +92,6 @@ class HyperDeck(Device):
             payload = payload[0]
 
         handler_method_name = "_recv_{}".format(code)
-        print code, payload, extra
         if hasattr(self, handler_method_name) and callable(getattr(self, handler_method_name)):
             getattr(self, handler_method_name)(payload, extra)
         else:

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -190,6 +190,7 @@ class HyperDeck(Device):
 
     def stop(self):
         self.socket.send('stop\r\n')
+        self._state['transport']['status'] = TransportState.STOPPED  # Otherwise we don't get a notification about it
 
     def play(self, single_clip=None, speed=None, loop=None):
         if single_clip is None and speed is None and loop is None:

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -15,10 +15,17 @@ class HyperDeck(Device):
         self.socket.connect(self.remote)
         self._run_recv_thread = True
         self._data_buffer = ''
+        self._initialiseState()
+
         if not (self._recv_thread and self._recv_thread.is_alive()):
             self._recv_thread = Thread(target=self._receive)
             self._recv_thread.daemon = True
             self._recv_thread.start()
+
+    def _initialiseState(self):
+        self._state = {
+            'connection': {}
+        }
 
     def deinitialise(self):
         self._run_recv_thread = False
@@ -55,4 +62,8 @@ class HyperDeck(Device):
             self.log.debug("Unhandled packet type {}: {}".format(code, payload))
 
     def _recv_500(self, payload, extra):
-        print payload, extra
+        for paramline in extra:
+            param, value = paramline.split(": ")
+            self._state['connection'][param] = value
+        self.socket.send('transport info\r\n')
+        self.socket.send('notify: transport: true\r\n')

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -172,3 +172,16 @@ class HyperDeck(Device):
 
     def stop(self):
         self.socket.send('stop\r\n')
+
+    def play(self, single_clip=None, speed=None, loop=None):
+        if single_clip is None and speed is None and loop is None:
+            self.socket.send('play\r\n')
+        else:
+            cmd = 'play: '
+            if single_clip is not None:
+                cmd += 'single clip: {} '.format('true' if single_clip else 'false')
+            if speed is not None:
+                cmd += 'speed: {} '.format(speed)
+            if loop is not None:
+                cmd += 'loop: {} '.format('true' if loop else 'false')
+            self.socket.send(cmd.strip() + '\r\n')

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -1,0 +1,58 @@
+from avx.devices.Device import Device
+from socket import socket
+from threading import Thread
+from time import sleep
+
+
+class HyperDeck(Device):
+    def __init__(self, deviceID, ipAddress, port=9993):
+        super(HyperDeck, self).__init__(deviceID)
+        self.remote = (ipAddress, port)
+        self._recv_thread = None
+
+    def initialise(self):
+        self.socket = socket()
+        self.socket.connect(self.remote)
+        self._run_recv_thread = True
+        self._data_buffer = ''
+        if not (self._recv_thread and self._recv_thread.is_alive()):
+            self._recv_thread = Thread(target=self._receive)
+            self._recv_thread.daemon = True
+            self._recv_thread.start()
+
+    def deinitialise(self):
+        self._run_recv_thread = False
+
+    def _receive(self):
+        while self._run_recv_thread:
+            data = self.socket.recv(4096)
+            if data == '':
+                self.log.warn("Connection closed - attempting to reconnect")
+                sleep(5)
+                self.initialise()
+            else:
+                # In case the response is larger than the recv buffer
+                # we need to check for a completed message - that is,
+                # one with an empty line at the end
+                self._data_buffer += data
+                if self._data_buffer[-4:] == "\r\n\r\n":
+                    self._handle_data(self._data_buffer)
+                    self._data_buffer = ''
+
+    def _handle_data(self, data):
+        # data packets are of form '000 payload text[:\r\nextra text]\r\n\r\n'
+        code = data[0:3]
+        payload = data[4:].strip().split("\r\n")
+        extra = []
+        if payload[0][-1] == ":":
+            extra = payload[1:]
+            payload = payload[0]
+
+        handler_method_name = "_recv_{}".format(code)
+        if hasattr(self, handler_method_name) and callable(getattr(self, handler_method_name)):
+            getattr(self, handler_method_name)(payload, extra)
+        else:
+            self.log.debug("Unhandled packet type {}: {}".format(code, payload))
+
+    def _recv_500(self, payload, extra):
+        print payload, extra

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -152,3 +152,15 @@ class HyperDeck(Device):
 
     def getSlotsState(self):
         return self._state['slots']
+
+########
+# Transport controls
+########
+    def record(self, clip_name=None):
+        if clip_name:
+            self.socket.send('record: name: {}\r\n'.format(clip_name))
+        else:
+            self.socket.send('record\r\n')
+
+    def stop(self):
+        self.socket.send('stop\r\n')

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -185,3 +185,12 @@ class HyperDeck(Device):
             if loop is not None:
                 cmd += 'loop: {} '.format('true' if loop else 'false')
             self.socket.send(cmd.strip() + '\r\n')
+
+    def gotoClip(self, clipID):
+        self.socket.send('goto: clip id: {}\r\n'.format(clipID))
+
+    def next(self):
+        self.gotoClip('+1')
+
+    def prev(self):
+        self.gotoClip('-1')

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -86,6 +86,9 @@ class HyperDeck(Device):
 
     def deinitialise(self):
         self._run_recv_thread = False
+        self._isConnected = False
+        if self.socket:
+            self.socket.close()
 
     def _receive(self):
         while self._run_recv_thread:

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -30,6 +30,8 @@ def _bool(string):
 
 
 def _int(string):
+    if string == "none":
+        return None
     try:
         return int(string)
     except ValueError:
@@ -113,6 +115,7 @@ class HyperDeck(Device):
 
     def _recv_208(self, payload, extra):
         mapping = {
+            'clip id': _int,
             'status': TransportState,
             'loop': _bool,
             'single clip': _bool,
@@ -140,3 +143,12 @@ class HyperDeck(Device):
 
     def _recv_502(self, payload, extra):
         self._recv_202(payload, extra)
+
+########
+# Getters
+########
+    def getTransportState(self):
+        return self._state['transport']
+
+    def getSlotsState(self):
+        return self._state['slots']

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -16,6 +16,19 @@ class TransportState(Enum):
     RECORD = 'record'
 
 
+def _bool(string):
+    if string == "true":
+        return True
+    return False
+
+
+def _int(string):
+    try:
+        return int(string)
+    except ValueError:
+        return string
+
+
 class HyperDeck(Device):
     def __init__(self, deviceID, ipAddress, port=9993):
         super(HyperDeck, self).__init__(deviceID)
@@ -89,7 +102,11 @@ class HyperDeck(Device):
 
     def _recv_208(self, payload, extra):
         mapping = {
-            'status': lambda s: TransportState(s)
+            'status': TransportState,
+            'loop': _bool,
+            'single clip': _bool,
+            'speed': _int,
+            'slot id': _int
         }
         self._store_state('transport', extra, mapping)
 

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -111,4 +111,4 @@ class HyperDeck(Device):
         self._store_state('transport', extra, mapping)
 
     def _recv_508(self, payload, extra):
-        self._store_state('transport', extra)
+        self._recv_208(payload, extra)

--- a/src/avx/devices/net/tests/TestHyperDeck.py
+++ b/src/avx/devices/net/tests/TestHyperDeck.py
@@ -1,0 +1,27 @@
+import unittest
+from avx.devices.net.hyperdeck import HyperDeck
+from mock import MagicMock, call
+
+
+class TestHyperDeck(unittest.TestCase):
+    def setUp(self):
+        self.deck = HyperDeck("test", "127.0.0.1")
+        self.deck.socket = MagicMock()
+        self.deck._initialiseState()
+
+    def testReceiveInit(self):
+        self.deck._handle_data(
+            '''500 connection info:\r
+protocol version: 1234\r
+model: Test HyperDeck\r
+\r
+\r
+'''
+        )
+
+        self.assertEqual('1234', self.deck._state['connection']['protocol version'])
+        self.assertEqual('Test HyperDeck', self.deck._state['connection']['model'])
+        self.assertEqual(
+            [call.send('transport info\r\n'), call.send('notify: transport: true\r\n')],
+            self.deck.socket.method_calls
+        )

--- a/src/avx/devices/net/tests/TestHyperDeck.py
+++ b/src/avx/devices/net/tests/TestHyperDeck.py
@@ -1,5 +1,6 @@
 import unittest
-from avx.devices.net.hyperdeck import HyperDeck, TransportState, SlotState
+from avx.devices.net.hyperdeck import HyperDeck, TransportState, SlotState,\
+    MessageTypes
 from mock import MagicMock, call
 
 
@@ -46,6 +47,8 @@ loop: false
         self.assertEqual(100, self.deck._state['transport']['speed'])
         self.assertEqual(False, self.deck._state['transport']['loop'])
 
+        self.deck.broadcast.reset_mock()
+
         self._handle_data(
             '''508 transport info:
 status: play
@@ -66,6 +69,7 @@ loop: true
             'loop': True
         }
         self.assertEqual(expected, self.deck.getTransportState())
+        self.deck.broadcast.assert_called_once_with(MessageTypes.TRANSPORT_STATE_CHANGED, expected)
 
     def testReceiveSlotInfo(self):
         self._handle_data(
@@ -81,6 +85,8 @@ video format: 1080p25
         self.assertEqual(97, self.deck._state['slots'][1]['recording time'])
         self.assertEqual(SlotState.MOUNTED, self.deck._state['slots'][1]['status'])
         self.assertEqual('Media', self.deck._state['slots'][1]['volume name'])
+
+        self.deck.broadcast.reset_mock()
 
         self._handle_data(
             '''502 slot info:
@@ -102,6 +108,7 @@ status: error
             }
         }
         self.assertEqual(expected, self.deck.getSlotsState())
+        self.deck.broadcast.assert_called_once_with(MessageTypes.SLOT_STATE_CHANGED, expected)
 
     def testRecord(self):
         self.deck.record()

--- a/src/avx/devices/net/tests/TestHyperDeck.py
+++ b/src/avx/devices/net/tests/TestHyperDeck.py
@@ -1,5 +1,5 @@
 import unittest
-from avx.devices.net.hyperdeck import HyperDeck
+from avx.devices.net.hyperdeck import HyperDeck, TransportState
 from mock import MagicMock, call
 
 
@@ -41,4 +41,4 @@ loop: false\r
 '''
         )
 
-        self.assertEqual('preview', self.deck._state['transport']['status'])
+        self.assertEqual(TransportState.PREVIEW, self.deck._state['transport']['status'])

--- a/src/avx/devices/net/tests/TestHyperDeck.py
+++ b/src/avx/devices/net/tests/TestHyperDeck.py
@@ -102,3 +102,15 @@ status: error
             }
         }
         self.assertEqual(expected, self.deck.getSlotsState())
+
+    def testRecord(self):
+        self.deck.record()
+        self.deck.socket.send.assert_called_once_with('record\r\n')
+        self.deck.socket.send.reset_mock()
+
+        self.deck.record('my clip name')
+        self.deck.socket.send.assert_called_once_with('record: name: my clip name\r\n')
+
+    def testStop(self):
+        self.deck.stop()
+        self.deck.socket.send.assert_called_once_with('stop\r\n')

--- a/src/avx/devices/net/tests/TestHyperDeck.py
+++ b/src/avx/devices/net/tests/TestHyperDeck.py
@@ -130,3 +130,11 @@ status: error
         self.deck.play(single_clip=False, speed=20, loop=True)
         self.deck.socket.send.assert_called_once_with('play: single clip: false speed: 20 loop: true\r\n')
         self.deck.socket.send.reset_mock()
+
+    def testNext(self):
+        self.deck.next()
+        self.deck.socket.send.assert_called_once_with('goto: clip id: +1\r\n')
+
+    def testPrev(self):
+        self.deck.prev()
+        self.deck.socket.send.assert_called_once_with('goto: clip id: -1\r\n')

--- a/src/avx/devices/net/tests/TestHyperDeck.py
+++ b/src/avx/devices/net/tests/TestHyperDeck.py
@@ -55,6 +55,18 @@ loop: true
         self.assertEqual(TransportState.PLAYING, self.deck._state['transport']['status'])
         self.assertEqual(True, self.deck._state['transport']['loop'])
 
+        expected = {
+            'status': TransportState.PLAYING,
+            'speed': 100,
+            'slot id': None,
+            'display timecode': '1:2:3',
+            'timecode': 'foo',
+            'clip id': None,
+            'video format': '1080p25',
+            'loop': True
+        }
+        self.assertEqual(expected, self.deck.getTransportState())
+
     def testReceiveSlotInfo(self):
         self._handle_data(
             '''202 slot info:
@@ -79,3 +91,14 @@ status: error
 
         self.assertEqual(97, self.deck._state['slots'][1]['recording time'])
         self.assertEqual(SlotState.ERROR, self.deck._state['slots'][1]['status'])
+
+        expected = {
+            1: {
+                'slot id': 1,
+                'status': SlotState.ERROR,
+                'volume name': 'Media',
+                'recording time': 97,
+                'video format': '1080p25'
+            }
+        }
+        self.assertEqual(expected, self.deck.getSlotsState())

--- a/src/avx/devices/net/tests/TestHyperDeck.py
+++ b/src/avx/devices/net/tests/TestHyperDeck.py
@@ -45,3 +45,12 @@ loop: false
         self.assertEqual(TransportState.PREVIEW, self.deck._state['transport']['status'])
         self.assertEqual(100, self.deck._state['transport']['speed'])
         self.assertEqual(False, self.deck._state['transport']['loop'])
+
+        self._handle_data(
+            '''508 transport info:
+status: play
+loop: true
+'''
+        )
+        self.assertEqual(TransportState.PLAYING, self.deck._state['transport']['status'])
+        self.assertEqual(True, self.deck._state['transport']['loop'])

--- a/src/avx/devices/net/tests/TestHyperDeck.py
+++ b/src/avx/devices/net/tests/TestHyperDeck.py
@@ -10,13 +10,14 @@ class TestHyperDeck(unittest.TestCase):
         self.deck.broadcast = MagicMock()
         self.deck._initialiseState()
 
+    def _handle_data(self, msg):
+        self.deck._handle_data(msg.replace('\n', '\r\n'))
+
     def testReceiveInit(self):
-        self.deck._handle_data(
-            '''500 connection info:\r
-protocol version: 1234\r
-model: Test HyperDeck\r
-\r
-\r
+        self._handle_data(
+            '''500 connection info:
+protocol version: 1234
+model: Test HyperDeck
 '''
         )
 
@@ -28,17 +29,19 @@ model: Test HyperDeck\r
         )
 
     def testReceiveTransportInfo(self):
-        self.deck._handle_data(
-            '''208 transport info:\r
-status: preview\r
-speed: 100\r
-slot id: none\r
-display timecode: 1:2:3\r
-timecode: foo\r
-clip id: none\r
-video format: 1080p25\r
-loop: false\r
+        self._handle_data(
+            '''208 transport info:
+status: preview
+speed: 100
+slot id: none
+display timecode: 1:2:3
+timecode: foo
+clip id: none
+video format: 1080p25
+loop: false
 '''
         )
 
         self.assertEqual(TransportState.PREVIEW, self.deck._state['transport']['status'])
+        self.assertEqual(100, self.deck._state['transport']['speed'])
+        self.assertEqual(False, self.deck._state['transport']['loop'])

--- a/src/avx/devices/net/tests/TestHyperDeck.py
+++ b/src/avx/devices/net/tests/TestHyperDeck.py
@@ -121,6 +121,7 @@ status: error
     def testStop(self):
         self.deck.stop()
         self.deck.socket.send.assert_called_once_with('stop\r\n')
+        self.assertEqual(TransportState.STOPPED, self.deck._state['transport']['status'])
 
     def testPlay(self):
         self.deck.play()

--- a/src/avx/devices/net/tests/TestHyperDeck.py
+++ b/src/avx/devices/net/tests/TestHyperDeck.py
@@ -121,3 +121,12 @@ status: error
     def testStop(self):
         self.deck.stop()
         self.deck.socket.send.assert_called_once_with('stop\r\n')
+
+    def testPlay(self):
+        self.deck.play()
+        self.deck.socket.send.assert_called_once_with('play\r\n')
+        self.deck.socket.send.reset_mock()
+
+        self.deck.play(single_clip=False, speed=20, loop=True)
+        self.deck.socket.send.assert_called_once_with('play: single clip: false speed: 20 loop: true\r\n')
+        self.deck.socket.send.reset_mock()

--- a/src/avx/devices/net/tests/TestHyperDeck.py
+++ b/src/avx/devices/net/tests/TestHyperDeck.py
@@ -7,6 +7,7 @@ class TestHyperDeck(unittest.TestCase):
     def setUp(self):
         self.deck = HyperDeck("test", "127.0.0.1")
         self.deck.socket = MagicMock()
+        self.deck.broadcast = MagicMock()
         self.deck._initialiseState()
 
     def testReceiveInit(self):
@@ -25,3 +26,19 @@ model: Test HyperDeck\r
             [call.send('transport info\r\n'), call.send('notify: transport: true\r\n')],
             self.deck.socket.method_calls
         )
+
+    def testReceiveTransportInfo(self):
+        self.deck._handle_data(
+            '''208 transport info:\r
+status: preview\r
+speed: 100\r
+slot id: none\r
+display timecode: 1:2:3\r
+timecode: foo\r
+clip id: none\r
+video format: 1080p25\r
+loop: false\r
+'''
+        )
+
+        self.assertEqual('preview', self.deck._state['transport']['status'])


### PR DESCRIPTION
This adds basic initial support for the Blackmagic Design HyperDeck TCP control protocol.

At the moment, getting transport and slot information is supported, as are the basic transport controls (play, stop, record, skip forward/back).

Jog, configuration, etc are not yet supported.

Closes #67.