### PR TITLE
Generate synthetic ATEM tally data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 - pip install pycodestyle coveralls
 - pip install --upgrade setuptools
 script:
-- pycodestyle --ignore=E501,W503 src
+- pycodestyle --ignore=E501,W504 src
 - python setup.py test
 after_success: coveralls
 before_deploy: sed -i -e "s/\.dev//" setup.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ python:
 env:
 - PYTEST_ADDOPTS="--cov=avx"
 install:
-- pip install pep8 coveralls
+- pip install pycodestyle coveralls
 - pip install --upgrade setuptools
 script:
-- pep8 --ignore=E501 src
+- pycodestyle --ignore=E501,W503 src
 - python setup.py test
 after_success: coveralls
 before_deploy: sed -i -e "s/\.dev//" setup.cfg
@@ -20,4 +20,3 @@ deploy:
   on:
     tags: true
   skip_cleanup: true
-

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Built-in message types currently include:
 
 * List of connected clients is no longer written to the config file, but instead
   to its own state file under `/var/lib/avx/`.
-* Added ATEM functions for upstream keyers
+* Added ATEM functions for upstream keyers and Super Source
 * Added "synthetic" tally for ATEM switcher giving sources per M/E bus
 
 ### v1.3.1 (2018-12-02)

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Built-in message types currently include:
 
 * List of connected clients is no longer written to the config file, but instead
   to its own state file under `/var/lib/avx/`.
+* Added ATEM functions for upstream keyers
+* Added "synthetic" tally for ATEM switcher giving sources per M/E bus
 
 ### v1.3.1 (2018-12-02)
 

--- a/src/avx/PyroUtils.py
+++ b/src/avx/PyroUtils.py
@@ -5,9 +5,9 @@ import Pyro4
 
 
 def setHostname():
-        ip = getHostname()
-        logging.info("Using " + ip + " as hostname")
-        Pyro4.config.HOST = ip
+    ip = getHostname()
+    logging.info("Using " + ip + " as hostname")
+    Pyro4.config.HOST = ip
 
 
 def getHostname():

--- a/src/avx/_version.py
+++ b/src/avx/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.3.1"
+__version__ = "1.4.0-beta1"

--- a/src/avx/devices/net/atem/atem.py
+++ b/src/avx/devices/net/atem/atem.py
@@ -67,7 +67,11 @@ class ATEM(Device, ATEMGetter, ATEMSender, ATEMReceiver):
             'audio': {},
             'tally_by_index': {},
             'tally': {},
-            'transition': {}
+            'transition': {},
+            'supersource': {
+                'boxes': [{}, {}, {}, {}]
+            }  # Later ATEM models have multiple SSrc - this will need to change
+               # to support later versions of the protocol
         }
         self._cameracontrol = {}
 

--- a/src/avx/devices/net/atem/constants.py
+++ b/src/avx/devices/net/atem/constants.py
@@ -176,6 +176,7 @@ class MessageTypes(object):
     ATEM_DISCONNECTED = _PREFIX + "Disconnected"
     AUX_OUTPUT_MAPPING = _PREFIX + "AuxOutputMapping"
     TALLY = _PREFIX + "Tally"
+    FULL_TALLY = _PREFIX + "FullTally"
     DSK_STATE = _PREFIX + "DownstreamKeyerState"
     INPUTS_CHANGED = _PREFIX + "InputsChanged"
     FTB_CHANGED = _PREFIX + "FadeToBlackChanged"

--- a/src/avx/devices/net/atem/constants.py
+++ b/src/avx/devices/net/atem/constants.py
@@ -185,6 +185,7 @@ class MessageTypes(object):
     TALLY = _PREFIX + "Tally"
     FULL_TALLY = _PREFIX + "FullTally"
     DSK_STATE = _PREFIX + "DownstreamKeyerState"
+    USK_STATE = _PREFIX + "UpstreamKeyerState"
     INPUTS_CHANGED = _PREFIX + "InputsChanged"
     FTB_CHANGED = _PREFIX + "FadeToBlackChanged"
     FTB_RATE_CHANGED = _PREFIX + "FtBRateChanged"

--- a/src/avx/devices/net/atem/constants.py
+++ b/src/avx/devices/net/atem/constants.py
@@ -168,6 +168,18 @@ class KeyType(Enum):
     DVE = 3
 
 
+class BevelType(Enum):
+    NONE = 0
+    IN_OUT = 1
+    IN = 2
+    OUT = 3
+
+
+class SuperSourceArtType(Enum):
+    BACKGROUND = 0
+    FOREGROUND = 1
+
+
 class MacroAction(Enum):
     RUN = 0
     STOP = 1

--- a/src/avx/devices/net/atem/constants.py
+++ b/src/avx/devices/net/atem/constants.py
@@ -161,6 +161,13 @@ class TransitionStyle(Enum):
     STING = 4
 
 
+class KeyType(Enum):
+    LUMA = 0
+    CHROMA = 1
+    PATTERN = 2
+    DVE = 3
+
+
 class MacroAction(Enum):
     RUN = 0
     STOP = 1

--- a/src/avx/devices/net/atem/constants.py
+++ b/src/avx/devices/net/atem/constants.py
@@ -202,3 +202,4 @@ class MessageTypes(object):
     FTB_CHANGED = _PREFIX + "FadeToBlackChanged"
     FTB_RATE_CHANGED = _PREFIX + "FtBRateChanged"
     TRANSITION_MIX_PROPERTIES_CHANGED = _PREFIX + "TrMxPropsChanged"
+    SUPER_SOURCE_CHANGED = _PREFIX + "SuperSourceChanged"

--- a/src/avx/devices/net/atem/getter.py
+++ b/src/avx/devices/net/atem/getter.py
@@ -37,6 +37,8 @@ class ATEMGetter(object):
             if box.get('enabled', False):
                 result.append(box['source'])
 
+        return result
+
     @requiresInit
     @assertTopology("mes", "me")
     def getFadeToBlackState(self, me=1):

--- a/src/avx/devices/net/atem/getter.py
+++ b/src/avx/devices/net/atem/getter.py
@@ -19,6 +19,9 @@ class ATEMGetter(object):
     def getDSKState(self):
         return self._state['dskeyers']
 
+    def getUSKState(self):
+        return self._state['keyers']
+
     @requiresInit
     @assertTopology("mes", "me")
     def getFadeToBlackState(self, me=1):

--- a/src/avx/devices/net/atem/getter.py
+++ b/src/avx/devices/net/atem/getter.py
@@ -22,6 +22,21 @@ class ATEMGetter(object):
     def getUSKState(self):
         return self._state['keyers']
 
+    def getSuperSourceState(self):
+        return self._state['supersource']
+
+    def _get_supersource_sources(self):
+        result = []
+        ssrc = self.getSuperSourceState()
+        if 'fill' in ssrc:
+            result.append(ssrc['fill'])
+        if 'key' in ssrc:
+            result.append(ssrc['key'])
+
+        for box in ssrc.get('boxes', []):
+            if box.get('enabled', False):
+                result.append(box['source'])
+
     @requiresInit
     @assertTopology("mes", "me")
     def getFadeToBlackState(self, me=1):

--- a/src/avx/devices/net/atem/receiver.py
+++ b/src/avx/devices/net/atem/receiver.py
@@ -339,6 +339,12 @@ class ATEMReceiver(object):
         border['light_source_direction'] = struct.unpack('!H', data[28:30])[0]
         border['light_source_altitude'] = data[30]
 
+        if self._isInitialized:
+            self.broadcast(
+                MessageTypes.SUPER_SOURCE_CHANGED,
+                self._state['supersource']
+            )
+
         self._broadcast_full_tally()
 
     def _recv_SSBP(self, data):
@@ -358,6 +364,12 @@ class ATEMReceiver(object):
         crop['bottom'] = struct.unpack('!H', data[14:16])[0]
         crop['left'] = struct.unpack('!H', data[16:18])[0]
         crop['right'] = struct.unpack('!H', data[18:20])[0]
+
+        if self._isInitialized:
+            self.broadcast(
+                MessageTypes.SUPER_SOURCE_CHANGED,
+                self._state['supersource']
+            )
 
         self._broadcast_full_tally()
 

--- a/src/avx/devices/net/atem/receiver.py
+++ b/src/avx/devices/net/atem/receiver.py
@@ -109,6 +109,7 @@ class ATEMReceiver(object):
         keyer = data[1]
         self._state['keyers'].setdefault(meIndex, {}).setdefault(keyer, {})['on'] = (data[2] != 0)
         if self._isInitialized:
+            self.broadcast(MessageTypes.USK_STATE, self._state['keyers'])
             self._broadcast_full_tally()
 
     def _recv_KeBP(self, data):

--- a/src/avx/devices/net/atem/sender.py
+++ b/src/avx/devices/net/atem/sender.py
@@ -140,6 +140,24 @@ class ATEMSender(object):
         self._sendCommand('FtbA', [me - 1, 0xA7, 0x59, 0x08])
 
 ########
+# USK
+########
+
+    @requiresInit
+    @assertTopology('mes', 'me')
+    def setUSKOnAir(self, me, usk, onAir):
+
+        me_keyers = self._system_config['keyers'].get(me, 0)
+        if usk > me_keyers:
+            raise InvalidArgumentException
+
+        self._sendCommand(
+            'CKOn',
+            [me - 1, usk - 1, 1 if onAir else 0, 0xBE, 0x07]
+        )
+        # Not sure about those magic values
+
+########
 # DSK
 ########
 

--- a/src/avx/devices/net/atem/sender.py
+++ b/src/avx/devices/net/atem/sender.py
@@ -216,7 +216,7 @@ class ATEMSender(object):
 
     @requiresInit
     @assertTopology('mes', 'me')
-    def setUSKLumaParams(self, me, usk, premultipled=None, clip=None, gain=None, invert=None):
+    def setUSKLumaParams(self, me, usk, preMultipled=None, clip=None, gain=None, invert=None):
         me_keyers = self._system_config['keyers'].get(me, 0)
         if usk > me_keyers:
             raise InvalidArgumentException

--- a/src/avx/devices/net/atem/sender.py
+++ b/src/avx/devices/net/atem/sender.py
@@ -346,10 +346,10 @@ class ATEMSender(object):
                 dsk - 1,
                 1 if preMultiplied else 0,
                 0
-            ] +
-            bytes_of(clip) +
-            bytes_of(gain) +
-            [
+            ]
+            + bytes_of(clip)
+            + bytes_of(gain)
+            + [
                 0, 0, 0, 0
             ]
         )

--- a/src/avx/devices/net/atem/sender.py
+++ b/src/avx/devices/net/atem/sender.py
@@ -248,8 +248,9 @@ class ATEMSender(object):
                 me - 1,
                 usk - 1,
                 1 if premultipled else 0
-            ] + bytes_of(clip)
-            + bytes_of(gain)
+            ] +
+            bytes_of(clip) +
+            bytes_of(gain) +
             + [
                 1 if invert else 0,
                 0,
@@ -345,10 +346,10 @@ class ATEMSender(object):
                 dsk - 1,
                 1 if preMultiplied else 0,
                 0
-            ]
-            + bytes_of(clip)
-            + bytes_of(gain)
-            + [
+            ] +
+            bytes_of(clip) +
+            bytes_of(gain) +
+            [
                 0, 0, 0, 0
             ]
         )

--- a/src/avx/devices/net/atem/sender.py
+++ b/src/avx/devices/net/atem/sender.py
@@ -346,10 +346,10 @@ class ATEMSender(object):
                 dsk - 1,
                 1 if preMultiplied else 0,
                 0
-            ]
-            + bytes_of(clip)
-            + bytes_of(gain)
-            + [
+            ] +
+            bytes_of(clip) +
+            bytes_of(gain) +
+            [
                 0, 0, 0, 0
             ]
         )

--- a/src/avx/devices/net/atem/sender.py
+++ b/src/avx/devices/net/atem/sender.py
@@ -244,10 +244,10 @@ class ATEMSender(object):
                 dsk - 1,
                 1 if preMultiplied else 0,
                 0
-            ] +
-            bytes_of(clip) +
-            bytes_of(gain) +
-            [
+            ]
+            + bytes_of(clip)
+            + bytes_of(gain)
+            + [
                 0, 0, 0, 0
             ]
         )

--- a/src/avx/devices/net/atem/sender.py
+++ b/src/avx/devices/net/atem/sender.py
@@ -146,21 +146,20 @@ class ATEMSender(object):
     @requiresInit
     @assertTopology('mes', 'me')
     def setUSKOnAir(self, me, usk, onAir):
-
-        me_keyers = self._system_config['keyers'].get(me, 0)
+        me_keyers = len(self._system_config['keyers'].get(me - 1, {}))
         if usk > me_keyers:
             raise InvalidArgumentException
 
         self._sendCommand(
             'CKOn',
-            [me - 1, usk - 1, 1 if onAir else 0, 0xBE, 0x07]
+            [me - 1, usk - 1, 1 if onAir else 0, 0x0A]
         )
         # Not sure about those magic values
 
     @requiresInit
     @assertTopology('mes', 'me')
     def setUSKType(self, me, usk, type, flying):
-        me_keyers = self._system_config['keyers'].get(me, 0)
+        me_keyers = len(self._system_config['keyers'].get(me - 1, {}))
         if usk > me_keyers:
             raise InvalidArgumentException
 
@@ -181,7 +180,7 @@ class ATEMSender(object):
     @requiresInit
     @assertTopology('mes', 'me')
     def setUSKKeySource(self, me, usk, source):
-        me_keyers = self._system_config['keyers'].get(me, 0)
+        me_keyers = len(self._system_config['keyers'].get(me - 1, {}))
         if usk > me_keyers:
             raise InvalidArgumentException
 
@@ -199,7 +198,7 @@ class ATEMSender(object):
     @requiresInit
     @assertTopology('mes', 'me')
     def setUSKFillSource(self, me, usk, source):
-        me_keyers = self._system_config['keyers'].get(me, 0)
+        me_keyers = len(self._system_config['keyers'].get(me - 1, {}))
         if usk > me_keyers:
             raise InvalidArgumentException
 
@@ -216,8 +215,8 @@ class ATEMSender(object):
 
     @requiresInit
     @assertTopology('mes', 'me')
-    def setUSKLumaParams(self, me, usk, preMultipled=None, clip=None, gain=None, invert=None):
-        me_keyers = self._system_config['keyers'].get(me, 0)
+    def setUSKLumaParams(self, me, usk, preMultiplied=None, clip=None, gain=None, invert=None):
+        me_keyers = len(self._system_config['keyers'].get(me - 1, {}))
         if usk > me_keyers:
             raise InvalidArgumentException
         if clip:
@@ -247,11 +246,11 @@ class ATEMSender(object):
                 set_mask,
                 me - 1,
                 usk - 1,
-                1 if premultipled else 0
+                1 if preMultiplied else 0
             ] +
             bytes_of(clip) +
             bytes_of(gain) +
-            + [
+            [
                 1 if invert else 0,
                 0,
                 0,

--- a/src/avx/devices/net/atem/sender.py
+++ b/src/avx/devices/net/atem/sender.py
@@ -398,6 +398,12 @@ class ATEMSender(object):
 # Super Source
 ########
 
+# Disabled since this code doesn't work - need to identify more magic
+# constants in the protocol I think...
+
+
+'''
+
     @requiresInit
     def setSuperSourceFill(self, source):
         return self.setSuperSourceParams(
@@ -616,3 +622,4 @@ class ATEMSender(object):
                 0
             ]
         )
+'''

--- a/src/avx/devices/net/atem/sender.py
+++ b/src/avx/devices/net/atem/sender.py
@@ -1,7 +1,9 @@
 from .constants import AudioSource, MacroAction, VideoSource, KeyType
-from .utils import requiresInit, assertTopology, bytes_of
+from .utils import requiresInit, assertTopology, bytes_of, array_pack
 from avx.devices.Device import InvalidArgumentException
 from avx.devices.net.atem.constants import MultiviewerLayout
+
+import struct
 
 
 #############
@@ -390,4 +392,229 @@ class ATEMSender(object):
         self._sendCommand(
             'RAMP',
             [mask, 0] + source_bytes + [(1 if source is None else 0), 0, 0, 0]
+        )
+
+########
+# Super Source
+########
+
+    @requiresInit
+    def setSuperSourceFill(self, source):
+        if not isinstance(source, VideoSource):
+            raise InvalidArgumentException
+        self._sendCommand(
+            'CSSc',
+            [
+                1, 0, 0, 0  # Only change fill source
+            ] +
+            self._resolveInputBytes(source) +
+            [0] * 30  # Set everything else to 0
+        )
+
+    @requiresInit
+    def setSuperSourceKey(self, source):
+        if not isinstance(source, VideoSource):
+            raise InvalidArgumentException
+        self._sendCommand(
+            'CSSc',
+            [
+                2, 0, 0, 0,  # Only change key source
+                0, 0,
+            ] +
+            self._resolveInputBytes(source) +
+            [0] * 28  # Set everything else to 0
+        )
+
+    @requiresInit
+    def setSuperSourceParams(
+        self,
+        foreground=None,
+        preMultiplied=None,
+        clip=None,
+        gain=None,
+        invert=None,
+        border_enabled=None,
+        border_bevel=None,
+        border_outer_width=None,
+        border_inner_width=None,
+        border_outer_softness=None,
+        border_inner_softness=None,
+        border_bevel_softness=None,
+        border_bevel_position=None,
+        border_hue=None,
+        border_saturation=None,
+        border_luma=None,
+        light_source_direction=None,
+        light_source_attitude=None
+    ):
+        mask = [0, 0, 0, 0]
+        if foreground is not None:
+            mask[0] |= 4
+        if preMultiplied is not None:
+            mask[0] |= 8
+        if clip is not None:
+            mask[0] |= 16
+        if gain is not None:
+            mask[0] |= 32
+        if invert is not None:
+            mask[0] |= 64
+        if border_enabled is not None:
+            mask[0] |= 128
+        if border_bevel is not None:
+            mask[1] |= 1
+        if border_outer_width is not None:
+            mask[1] |= 2
+        if border_inner_width is not None:
+            mask[1] |= 4
+        if border_outer_softness is not None:
+            mask[1] |= 8
+        if border_inner_softness is not None:
+            mask[1] |= 16
+        if border_bevel_softness is not None:
+            mask[1] |= 32
+        if border_bevel_position is not None:
+            mask[1] |= 64
+        if border_hue is not None:
+            mask[1] |= 128
+        if border_saturation is not None:
+            mask[2] |= 1
+        if border_luma is not None:
+            mask[2] |= 2
+        if light_source_direction is not None:
+            mask[2] |= 4
+        if light_source_attitude is not None:
+            mask[2] |= 8
+
+        self._sendCommand(
+            'CSSc',
+            mask +
+            [
+                0, 0, 0, 0,  # Not changing video sources
+                1 if foreground else 0,
+                1 if preMultiplied else 0
+            ] +
+            array_pack('!H', clip or 0) +
+            array_pack('!H', gain or 0) +
+            [
+                1 if invert else 0,
+                1 if border_enabled else 0,
+                border_bevel or 0,
+                0
+            ] +
+            array_pack('!H', border_outer_width or 0) +
+            array_pack('!H', border_inner_width or 0) +
+            [
+                border_outer_softness or 0,
+                border_inner_softness or 0,
+                border_bevel_softness or 0,
+                border_bevel_position or 0
+            ] +
+            array_pack('!H', border_hue or 0) +
+            array_pack('!H', border_saturation or 0) +
+            array_pack('!H', border_luma or 0) +
+            array_pack('!H', light_source_direction or 0) +
+            [
+                light_source_attitude or 0,
+                0
+            ]
+        )
+
+    @requiresInit
+    def setSuperSourceBoxSource(self, box, source):
+        if not isinstance(source, VideoSource):
+            raise InvalidArgumentException
+        if 0 > box or box > 3:
+            raise InvalidArgumentException
+        self._sendCommand(
+            'CSBP',
+            [
+                2, 0,  # Only change input source
+                box,
+                0
+            ] +
+            self._resolveInputBytes(source) +
+            [0] * 17  # Set everything else to 0
+        )
+
+    @requiresInit
+    def setSuperSourceBoxParams(
+        self,
+        box,
+        enabled=None,
+        position_x=None,
+        position_y=None,
+        size=None,
+        cropped=None,
+        crop_top=None,
+        crop_bottom=None,
+        crop_left=None,
+        crop_right=None
+    ):
+
+        if position_x is not None:
+            if position_x < -4800 or position_x > 4800:
+                raise InvalidArgumentException()
+        if position_y is not None:
+            if position_y < -4800 or position_y > 4800:
+                raise InvalidArgumentException()
+        if size is not None:
+            if size < 70 or size > 1000:
+                raise InvalidArgumentException()
+        if crop_top is not None:
+            if crop_top < 0 or crop_top > 18000:
+                raise InvalidArgumentException()
+        if crop_bottom is not None:
+            if crop_bottom < 0 or crop_bottom > 18000:
+                raise InvalidArgumentException()
+        if crop_left is not None:
+            if crop_left < 0 or crop_left > 18000:
+                raise InvalidArgumentException()
+        if crop_right is not None:
+            if crop_right < 0 or crop_right > 18000:
+                raise InvalidArgumentException()
+
+        mask_1 = 0
+        mask_2 = 0
+        if enabled is not None:
+            mask_1 |= 1
+        if position_x is not None:
+            mask_1 |= 4
+        if position_y is not None:
+            mask_1 |= 8
+        if size is not None:
+            mask_1 |= 16
+        if cropped is not None:
+            mask_1 |= 32
+        if crop_top is not None:
+            mask_1 |= 64
+        if crop_bottom is not None:
+            mask_1 |= 128
+        if crop_left is not None:
+            mask_2 |= 1
+        if crop_right is not None:
+            mask_2 |= 2
+
+        self._sendCommand(
+            'CSBP',
+            [
+                mask_1,
+                mask_2,
+                box,
+                1 if enabled else 0,
+                0, 0
+            ] +
+            bytes_of(position_x or 0) +
+            bytes_of(position_y or 0) +
+            array_pack('!h', size or 0) +
+            [
+                1 if cropped else 0,
+                0
+            ] +
+            array_pack('!H', crop_top or 0) +
+            array_pack('!H', crop_bottom or 0) +
+            array_pack('!H', crop_left or 0) +
+            array_pack('!H', crop_right or 0) +
+            [
+                0
+            ]
         )

--- a/src/avx/devices/net/atem/tests/TestATEMReceiver.py
+++ b/src/avx/devices/net/atem/tests/TestATEMReceiver.py
@@ -305,21 +305,21 @@ class TestATEMReceiver(BaseATEMTest):
                 'current': {
                     'style': TransitionStyle.WIPE,
                     'tied': {
-                        0: True,
-                        1: True,
-                        2: False,
-                        3: False,
-                        4: False
+                        'bkgd': True,
+                        'key1': True,
+                        'key2': False,
+                        'key3': False,
+                        'key4': False
                     }
                 },
                 'next': {
                     'style': TransitionStyle.STING,
                     'tied': {
-                        0: True,
-                        1: False,
-                        2: True,
-                        3: False,
-                        4: False
+                        'bkgd': True,
+                        'key1': False,
+                        'key2': True,
+                        'key3': False,
+                        'key4': False
                     }
                 }
             }

--- a/src/avx/devices/net/atem/tests/TestATEMReceiver.py
+++ b/src/avx/devices/net/atem/tests/TestATEMReceiver.py
@@ -49,8 +49,8 @@ class TestATEMReceiver(BaseATEMTest):
         # Remainder of bytes are unknowns
 
     def testRecv_MeC(self):
-        self.send_command('_MeC', [8, 27, 0])
-        self.assertEqual(27, self.atem._system_config['keyers'][8])
+        self.send_command('_MeC', [8, 3, 0])
+        self.assertEqual([0, 1, 2], self.atem._system_config['keyers'][8].keys())
 
     def testRecv_mpl(self):
         self.send_command('_mpl', [29, 42, 0])

--- a/src/avx/devices/net/atem/tests/TestATEMSender.py
+++ b/src/avx/devices/net/atem/tests/TestATEMSender.py
@@ -5,6 +5,8 @@ from avx.devices.net.atem.utils import byteArrayToString, bytes_of, \
     NotInitializedException
 from avx.devices.Device import InvalidArgumentException
 
+import pytest
+
 
 class TestATEMSender(BaseATEMTest):
     def assert_sent_packet(self, cmd, payload):
@@ -202,6 +204,7 @@ class TestATEMSender(BaseATEMTest):
 # Super Source
 ########
 
+    @pytest.mark.skip(reason='Code is not currently working and is commented out')
     def testSetSuperSourceFill(self):
         self.atem.setSuperSourceFill(VideoSource.COLOUR_BARS)
         self.assert_sent_packet(
@@ -216,6 +219,7 @@ class TestATEMSender(BaseATEMTest):
             ([0] * 30)
         )
 
+    @pytest.mark.skip(reason='Code is not currently working and is commented out')
     def testSetSuperSourceKey(self):
         self.atem.setSuperSourceKey(VideoSource.COLOUR_BARS)
         self.assert_sent_packet(
@@ -231,6 +235,7 @@ class TestATEMSender(BaseATEMTest):
             ([0] * 28)
         )
 
+    @pytest.mark.skip(reason='Code is not currently working and is commented out')
     def testSetSuperSourceParams(self):
         self.atem.setSuperSourceParams(
             foreground=True,
@@ -260,6 +265,7 @@ class TestATEMSender(BaseATEMTest):
             ] + ([0] * 13)
         )
 
+    @pytest.mark.skip(reason='Code is not currently working and is commented out')
     def testSetSuperSourceBoxSource(self):
         self.atem.setSuperSourceBoxSource(3, VideoSource.COLOUR_BARS)
         self.assert_sent_packet(
@@ -273,6 +279,7 @@ class TestATEMSender(BaseATEMTest):
             [0] * 17
         )
 
+    @pytest.mark.skip(reason='Code is not currently working and is commented out')
     def testSetSuperSourceBoxParams(self):
         self.atem.setSuperSourceBoxParams(
             2,

--- a/src/avx/devices/net/atem/tests/TestATEMSender.py
+++ b/src/avx/devices/net/atem/tests/TestATEMSender.py
@@ -197,3 +197,108 @@ class TestATEMSender(BaseATEMTest):
         self.atem.resetAudioMixerPeaks(AudioSource.XLR)
         self.assert_sent_packet('RAMP', [0x2, 0, 0x3, 0xE9, 0, 0, 0, 0])
         self.atem._socket.reset_mock()
+
+########
+# Super Source
+########
+
+    def testSetSuperSourceFill(self):
+        self.atem.setSuperSourceFill(VideoSource.COLOUR_BARS)
+        self.assert_sent_packet(
+            'CSSc',
+            [
+                0x1,
+                0,
+                0,
+                0
+            ] +
+            bytes_of(VideoSource.COLOUR_BARS.value) +
+            ([0] * 30)
+        )
+
+    def testSetSuperSourceKey(self):
+        self.atem.setSuperSourceKey(VideoSource.COLOUR_BARS)
+        self.assert_sent_packet(
+            'CSSc',
+            [
+                0x2,
+                0,
+                0,
+                0,
+                0, 0
+            ] +
+            bytes_of(VideoSource.COLOUR_BARS.value) +
+            ([0] * 28)
+        )
+
+    def testSetSuperSourceParams(self):
+        self.atem.setSuperSourceParams(
+            foreground=True,
+            clip=500,
+            gain=250,
+            border_outer_softness=42
+        )
+        self.assert_sent_packet(
+            'CSSc',
+            [
+                0x34,
+                0x08,
+                0,
+                0,
+                0, 0, 0, 0,
+                1,
+                0,
+                0x01, 0xF4,
+                0x00, 0xFA,
+                0,
+                0,
+                0,
+                0,
+                0, 0,
+                0, 0,
+                42
+            ] + ([0] * 13)
+        )
+
+    def testSetSuperSourceBoxSource(self):
+        self.atem.setSuperSourceBoxSource(3, VideoSource.COLOUR_BARS)
+        self.assert_sent_packet(
+            'CSBP',
+            [
+                2, 0,
+                3,
+                0
+            ] +
+            bytes_of(VideoSource.COLOUR_BARS.value) +
+            [0] * 17
+        )
+
+    def testSetSuperSourceBoxParams(self):
+        self.atem.setSuperSourceBoxParams(
+            2,
+            enabled=True,
+            position_x=0,
+            position_y=1234,
+            cropped=False,
+            crop_left=12345
+        )
+        self.assert_sent_packet(
+            'CSBP',
+            [
+                0x2D,
+                0x01,
+                2,
+                1,
+                0, 0,
+                0, 0,
+                0x04, 0xD2,
+                0, 0,
+                0,
+                0,
+                0, 0,
+                0, 0,
+                0x30, 0x39,
+                0, 0,
+                0
+            ]
+        )

--- a/src/avx/devices/net/atem/utils.py
+++ b/src/avx/devices/net/atem/utils.py
@@ -2,6 +2,7 @@ from avx.devices.Device import InvalidArgumentException
 
 import ctypes
 import inspect
+import struct
 
 
 def byteArrayToString(byteArray):
@@ -10,6 +11,10 @@ def byteArrayToString(byteArray):
 
 def bytes_of(val):
     return [(val >> 8), (val & 0xFF)]
+
+
+def array_pack(format, value):
+    return map(ord, struct.pack(format, value))
 
 
 class NotInitializedException(Exception):

--- a/src/avx/devices/net/hyperdeck.py
+++ b/src/avx/devices/net/hyperdeck.py
@@ -190,7 +190,6 @@ class HyperDeck(TCPDevice):
         '''
         self.send('disk list\r\n')
 
-
 ########
 # State setters
 ########


### PR DESCRIPTION
We create our own tally messages for each of the ATEM M/E buses, rather than take the ATEM-generated tally which only describes M/E 1.

Fixes #81.